### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,8 +110,7 @@ cd %SIMPLE_EIFFEL%\simple_env\Clib
 cl /c simple_env.c
 
 cd %SIMPLE_EIFFEL%\eiffel_sqlite_2025\Clib
-cl /c sqlite3.c
-cl /c esqlite.c
+build-x64-fts5.bat
 ```
 
 #### 4. Build simple_pkg


### PR DESCRIPTION
Use build-x64-fts5.bat instead of separate cl commands to avoid eif_eiffel.h not found error,